### PR TITLE
use proper name of bindable

### DIFF
--- a/src/components/buttons.html
+++ b/src/components/buttons.html
@@ -113,14 +113,14 @@
       </figure>
 
       <figure styles.figure>
-        <ux-button type="flat" material-effect="ripple">Button</ux-button>
-        <ux-button material-effect="ripple">Button</ux-button>
-        <ux-button type="fab" material-effect="ripple">
+        <ux-button type="flat" effect="ripple">Button</ux-button>
+        <ux-button effect="ripple">Button</ux-button>
+        <ux-button type="fab" effect="ripple">
           <span style="font-size: 26px">+</span>
         </ux-button>
 
         <code>
-          material-effect="ripple"
+          effect="ripple"
         </code>
       </figure>
     </section>


### PR DESCRIPTION
Not much, but it just seems that the bindable is called [`effect`](https://github.com/aurelia/ux/blob/master/src/button/ux-button.ts#L14) and there is no such thing as `material-effect` on a button.