### PR TITLE
feat(tooltips): Add tooltips examples

### DIFF
--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -140,7 +140,9 @@
             "main": "index",
             "resources": [
               "./button/ux-button.html",
-              "./button/ux-button-theme.css"
+              "./button/ux-button-theme.css",
+              "./tooltip/ux-tooltip.html",
+              "./tooltip/ux-tooltip-theme.css"
             ]
           }
         ]

--- a/src/components/tooltips.css
+++ b/src/components/tooltips.css
@@ -1,0 +1,25 @@
+styles.feature {
+  margin: 40px 0 20px;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+}
+
+styles.figure {
+  background: ${$swatches.grey.p200};
+  display: flex;
+  width: 320px;
+  height: 320px;
+  position:relative;
+  margin-bottom: 20px;
+}
+
+styles.figure > ux-tooltip {
+  margin: auto;
+}
+
+styles.figure > code {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+}

--- a/src/components/tooltips.html
+++ b/src/components/tooltips.html
@@ -1,0 +1,184 @@
+<template>
+  <require from='../common.css#ux'></require>
+  <require from="./tooltips.css#ux"></require>
+
+  <main styles.main>
+    <h1 styles.header>
+      &lt;ux-tooltip&gt;&lt;/ux-tooltip&gt;
+    </h1>
+
+    <p styles.description>
+      The <code>ux-tooltip</code> element is a text label that appear when the user hovers over, focuses on, or touches an element is used to indicate that a user can take an action.
+      It comes in 4 positions: <em>top</em>, <em>right</em>,  <em>bottom</em>(default) and <em>left</em> which can be configured either on the tooltip instance or on the theme object, using the <em>position</em> property.
+    </p>
+
+    <section styles.feature>
+      <figure styles.figure>
+        <ux-tooltip position="top">
+          <div slot="tooltip-target">
+            <ux-button>Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+
+        <code>
+          position="top"
+        </code>
+      </figure>
+
+      <figure styles.figure>
+        <ux-tooltip position="right">
+          <div slot="tooltip-target">
+            <ux-button>Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+
+        <code>
+          position="right"
+        </code>
+      </figure>
+
+      <figure styles.figure>
+        <ux-tooltip>
+          <div slot="tooltip-target">
+            <ux-button>Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+
+        <code>
+          position="bottom" (default)
+        </code>
+      </figure>
+
+      <figure styles.figure>
+        <ux-tooltip position="left">
+          <div slot="tooltip-target">
+            <ux-button>Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+
+        <code>
+          position="left"
+        </code>
+      </figure>
+    </section>
+
+    <p styles.description>
+      Material tooltips have a ease effect by default, however that can be turned off using the <code>effect</code> property.
+      As with all properties, this can be specified per design language, using the design language prefix.
+    </p>
+
+    <section styles.feature>
+      <figure styles.figure>
+        <ux-tooltip effect="none">
+          <div slot="tooltip-target">
+            <ux-button type="flat">Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+        <ux-tooltip effect="none">
+          <div slot="tooltip-target">
+            <ux-button>Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+        <ux-tooltip effect="none">
+          <div slot="tooltip-target">
+            <ux-button type="fab">
+              <span style="font-size: 26px">+</span>
+            </ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+
+        <code>
+          effect="none"
+        </code>
+      </figure>
+
+      <figure styles.figure>
+
+        <ux-tooltip effect="ease">
+          <div slot="tooltip-target">
+            <ux-button type="flat">Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+        <ux-tooltip effect="ease">
+          <div slot="tooltip-target">
+            <ux-button>Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+        <ux-tooltip effect="ease">
+          <div slot="tooltip-target">
+            <ux-button type="fab">
+              <span style="font-size: 26px">+</span>
+            </ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+
+        <code>
+          effect="ease"
+        </code>
+      </figure>
+
+      <figure styles.figure>
+        <ux-tooltip material-effect="ease">
+          <div slot="tooltip-target">
+            <ux-button type="flat">Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+        <ux-tooltip material-effect="ease">
+          <div slot="tooltip-target">
+            <ux-button>Button</ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+        <ux-tooltip material-effect="ease">
+          <div slot="tooltip-target">
+            <ux-button type="fab">
+              <span style="font-size: 26px">+</span>
+            </ux-button>
+          </div>
+          <div slot="tooltip-content">
+            Tooltip
+          </div>
+        </ux-tooltip>
+
+        <code>
+          material-effect="ease"
+        </code>
+      </figure>
+    </section>
+  </main>
+</template>

--- a/src/components/tooltips.ts
+++ b/src/components/tooltips.ts
@@ -1,0 +1,3 @@
+export class Tooltips {
+
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,5 +13,6 @@ export let routes = [
   { settings: { category: coreFeatures }, route: 'swatches', moduleId: './core-features/swatches', name: 'swatches', title: 'Swatches', nav: true },
   { settings: { category: coreFeatures }, route: 'theming', moduleId: './core-features/theming', name: 'theming', title: 'Theming', nav: true },
 
-  { settings: { category: components }, route: 'buttons', moduleId: './components/buttons', name: 'buttons', title: 'Buttons', nav: true }
+  { settings: { category: components }, route: 'buttons', moduleId: './components/buttons', name: 'buttons', title: 'Buttons', nav: true },
+  { settings: { category: components }, route: 'tooltips', moduleId: './components/tooltips', name: 'tooltips', title: 'Tooltips', nav: true }
 ]


### PR DESCRIPTION
Examples of `ux-tooltip` component introduce with
https://github.com/aurelia/ux/pull/23