### PR TITLE
fix(chip): amend ux-chip-input description

### DIFF
--- a/src/components/chips.html
+++ b/src/components/chips.html
@@ -100,7 +100,7 @@
 
     <p styles.description>
       The <code>ux-chip-input</code> element has a separator attribute that allows the default
-      separator to be overridden. The default seperator is ', '.
+      separator to be overridden. The default separator is ', '.
     </p>
 
     <section styles.feature>


### PR DESCRIPTION
Correct typo in ux-chip-input description on default separator